### PR TITLE
Only allow component imports

### DIFF
--- a/src/utils/cdk.test.ts
+++ b/src/utils/cdk.test.ts
@@ -1,7 +1,7 @@
 import { CodeMaker } from 'codemaker';
 import { Config } from './args';
 import { CdkBuilder, CDKTemplate } from './cdk';
-import { Imports, importType } from './imports';
+import { Imports } from './imports';
 
 const mockedCodeMaker: { [key: string]: jest.Mock } = {
   line: jest.fn(),
@@ -43,58 +43,24 @@ describe('The CdkBuilder class', () => {
       builder.addImports();
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
         2,
-        `import cdk = require("@aws-cdk/core")`
+        `import type { Construct, StackProps } from "@aws-cdk/core"`
+      );
+      expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
+        3,
+        `import { Stack } from "@aws-cdk/core"`
       );
     });
-
-    test('adds ALL style imports correctly', () => {
+    test('adds imports correctly', () => {
       const imports = new Imports();
       imports.imports = {
-        test: {
-          type: importType.ALL,
-          name: 'test',
-        },
+        test: ['Test'],
       };
       builder.imports = imports;
 
       builder.addImports();
       expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
-        3,
-        `import * as test from "test"`
-      );
-    });
-
-    test('adds REQUIRE style imports correctly', () => {
-      const imports = new Imports();
-      imports.imports = {
-        test: {
-          type: importType.REQUIRE,
-          name: 'test',
-        },
-      };
-      builder.imports = imports;
-
-      builder.addImports();
-      expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
-        3,
-        `import test = require("test")`
-      );
-    });
-
-    test('adds COMPONENT style imports correctly', () => {
-      const imports = new Imports();
-      imports.imports = {
-        test: {
-          type: importType.COMPONENT,
-          components: ['Test'],
-        },
-      };
-      builder.imports = imports;
-
-      builder.addImports();
-      expect(mockedCodeMaker.line).toHaveBeenNthCalledWith(
-        3,
-        `import {Test} from "test"`
+        4,
+        `import { Test } from "test"`
       );
     });
   });

--- a/src/utils/cdk.ts
+++ b/src/utils/cdk.ts
@@ -1,6 +1,6 @@
 import { CfnParameterProps } from '@aws-cdk/core';
 import { Config } from './args';
-import { Imports, importType } from './imports';
+import { Imports } from './imports';
 import { CodeMaker, toCamelCase } from 'codemaker';
 import * as path from 'path';
 
@@ -63,22 +63,14 @@ export class CdkBuilder {
   // TODO: Update this for our preferred style of imports
   addImports(): void {
     this.code.line();
-    this.code.line(`import cdk = require("@aws-cdk/core")`);
+    this.code.line(
+      `import type { Construct, StackProps } from "@aws-cdk/core"`
+    );
+    this.code.line(`import { Stack } from "@aws-cdk/core"`);
     Object.keys(this.imports.imports).forEach((lib) => {
-      const libProps = this.imports.imports[lib];
-      switch (libProps.type) {
-        case importType.ALL:
-          this.code.line(`import * as ${libProps.name} from "${lib}"`);
-          break;
-        case importType.REQUIRE:
-          this.code.line(`import ${libProps.name} = require("${lib}")`);
-          break;
-        case importType.COMPONENT:
-          this.code.line(
-            `import {${libProps.components?.join(', ')}} from "${lib}"`
-          );
-          break;
-      }
+      const components = this.imports.imports[lib];
+
+      this.code.line(`import { ${components?.join(', ')} } from "${lib}"`);
     });
     this.code.line();
   }

--- a/src/utils/cfn.test.ts
+++ b/src/utils/cfn.test.ts
@@ -3,7 +3,7 @@ import { CfnParser } from './cfn';
 import { mocked } from 'ts-jest/utils';
 import fs from 'fs';
 import yaml from 'js-yaml';
-import { Imports, importType } from './imports';
+import { Imports } from './imports';
 
 jest.mock('fs');
 const mockedFs = mocked(fs, true);
@@ -77,10 +77,7 @@ describe('The CfnParser class', () => {
       });
 
       expect(parser.imports.imports).toMatchObject({
-        '@guardian/cdk/lib/constructs/core': {
-          type: importType.COMPONENT,
-          components: ['GuStringParameter'],
-        },
+        '@guardian/cdk/lib/constructs/core': ['GuStringParameter'],
       });
     });
 
@@ -104,10 +101,7 @@ describe('The CfnParser class', () => {
       });
 
       expect(parser.imports.imports).toMatchObject({
-        '@guardian/cdk/lib/constructs/core': {
-          type: importType.COMPONENT,
-          components: ['GuParameter'],
-        },
+        '@guardian/cdk/lib/constructs/core': ['GuParameter'],
       });
     });
 

--- a/src/utils/cfn.ts
+++ b/src/utils/cfn.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import { Config } from './args';
-import {toCamelCase} from 'codemaker'
-import { Imports, importType } from './imports';
+import { toCamelCase } from 'codemaker';
+import { Imports } from './imports';
 import { CDKTemplate } from './cdk';
 import { camelCaseObjectKeys } from './utils';
 
@@ -66,27 +66,25 @@ export class CfnParser {
 
   parseParameters = (cfn: CFNTemplate): void => {
     Object.keys(cfn.Parameters).forEach((key) => {
-      const parameters = camelCaseObjectKeys(cfn.Parameters[key])
+      const parameters = camelCaseObjectKeys(cfn.Parameters[key]);
 
-      const similarConstuct = this.getSimilarConstructs(key)
+      const similarConstuct = this.getSimilarConstructs(key);
       if (similarConstuct) {
-        parameters.comment = similarConstuct
+        parameters.comment = similarConstuct;
       }
 
       if (parameters.type === 'String') {
-        this.imports.addImport('@guardian/cdk/lib/constructs/core', {
-          type: importType.COMPONENT,
-          components: ['GuStringParameter'],
-        });
+        this.imports.addImport('@guardian/cdk/lib/constructs/core', [
+          'GuStringParameter',
+        ]);
         this.template.Parameters[key] = {
           ...parameters,
           parameterType: 'GuStringParameter',
         };
       } else {
-        this.imports.addImport('@guardian/cdk/lib/constructs/core', {
-          type: importType.COMPONENT,
-          components: ['GuParameter'],
-        });
+        this.imports.addImport('@guardian/cdk/lib/constructs/core', [
+          'GuParameter',
+        ]);
         this.template.Parameters[key] = {
           ...parameters,
           parameterType: 'GuParameter',

--- a/src/utils/imports.test.ts
+++ b/src/utils/imports.test.ts
@@ -1,26 +1,26 @@
-import { Imports, importType } from "./imports"
+import { Imports } from './imports';
 
-describe("The Imports class", () => {
-  describe("addImport function", () => {
+describe('The Imports class', () => {
+  describe('addImport function', () => {
     test("adds an import if it doesn't previously exist", () => {
-      const imports = new Imports()
-      imports.addImport("test", {type: importType.REQUIRE, name: "test"})
-      expect(imports.imports).toMatchObject({test: {type: importType.REQUIRE, name: "test"}})
-    })
+      const imports = new Imports();
+      imports.addImport('test', ['one']);
+      expect(imports.imports).toMatchObject({
+        test: ['one'],
+      });
+    });
 
-    test("throws an error if the import has already been added using a different style", () => {
-      const imports = new Imports()
-      imports.addImport("test", {type: importType.REQUIRE, name: "test"})
-      expect(() => imports.addImport("test", {type: importType.ALL, name: "test"})).toThrow(`This library has already been added but using a different import type - Current: require Requested: all`)
-    })
+    test('merges individual components if the import has already been added using component style', () => {
+      const imports = new Imports();
+      imports.addImport('test', ['one']);
+      expect(imports.imports).toMatchObject({
+        test: ['one'],
+      });
 
-    test("merges individual components if the import has already been added using component style", () => {
-      const imports = new Imports()
-      imports.addImport("test", {type: importType.COMPONENT, components: ["one"]})
-      expect(imports.imports).toMatchObject({"test": {type: importType.COMPONENT, components: ["one"]}})
-
-      imports.addImport("test", {type: importType.COMPONENT, components: ["two"]})
-      expect(imports.imports).toMatchObject({"test": {type: importType.COMPONENT, components: ["one", "two"]}})
-    })
-  })
-})
+      imports.addImport('test', ['two']);
+      expect(imports.imports).toMatchObject({
+        test: ['one', 'two'],
+      });
+    });
+  });
+});

--- a/src/utils/imports.ts
+++ b/src/utils/imports.ts
@@ -1,47 +1,14 @@
-export enum importType {
-  REQUIRE="require",
-  ALL="all",
-  COMPONENT="component"
-}
-
-interface BaseImportProps {
-  type: importType;
-}
-
-interface ComponentImportProps extends BaseImportProps {
-  type: importType.COMPONENT;
-  components: string[];
-}
-
-interface OtherImportProps extends BaseImportProps {
-  type: importType.ALL | importType.REQUIRE;
-  name: string;
-}
-
 export class Imports {
-  imports: { [lib: string]: ComponentImportProps | OtherImportProps } = {};
+  imports: { [lib: string]: string[] } = {};
 
-  addImport(lib: string, props: ComponentImportProps | OtherImportProps): void {
+  addImport(lib: string, components: string[]): void {
     if (!this.imports[lib]) {
-      this.imports[lib] = props;
+      this.imports[lib] = components;
       return;
     }
 
-    if (this.imports[lib].type !== props.type) {
-      throw new Error(
-        `This library has already been added but using a different import type - Current: ${this.imports[lib].type} Requested: ${props.type}`
-      );
-    }
-
-    if (props.type === importType.COMPONENT) {
-      const foo = props as ComponentImportProps
-      const bar = this.imports[lib] as ComponentImportProps
-
-      bar.components = [
-        ...new Set(
-          (bar.components || []).concat(foo.components || [])
-        ),
-      ];
-    }
+    this.imports[lib] = [
+      ...new Set((this.imports[lib] || []).concat(components || [])),
+    ];
   }
 }


### PR DESCRIPTION
## What does this change?

This PR updates the imports logic to only allow the `import { Component } from 'library'` style.

## How to test

- Run `yarn test` to confirm the tests all pass.
- Migrate an existing stack and check that the imports all match the required style.
