### PR TITLE
Rename to CDK CLI

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-   CDK Migrator
+   CDK CLI
    Copyright 2011-2020 Guardian News & Media Ltd
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -1,43 +1,50 @@
-cdk-migrator
-========
+# cdk-cli
 
 **This tool is a work in progress. It relies on the as-yet-unpublished Guardian CDK library.**
 
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
-[![Version](https://img.shields.io/npm/v/cdk-migrator.svg)](https://npmjs.org/package/cdk-migrator)
-[![Downloads/week](https://img.shields.io/npm/dw/cdk-migrator.svg)](https://npmjs.org/package/cdk-migrator)
-[![License](https://img.shields.io/npm/l/cdk-migrator.svg)](https://github.com/guardian/cdk-migrator/blob/master/package.json)
+[![Version](https://img.shields.io/npm/v/cdk-cli.svg)](https://npmjs.org/package/cdk-cli)
+[![Downloads/week](https://img.shields.io/npm/dw/cdk-cli.svg)](https://npmjs.org/package/cdk-cli)
+[![License](https://img.shields.io/npm/l/cdk-cli.svg)](https://github.com/guardian/cdk-cli/blob/master/package.json)
 
 <!-- toc -->
-* [Usage](#usage)
-* [Commands](#commands)
+
+- [Usage](#usage)
+- [Commands](#commands)
 <!-- tocstop -->
+
 # Usage
+
 <!-- usage -->
+
 ```sh-session
-$ npm install -g @guardian/cdk-migrator
-$ cdk-migrator COMMAND
+$ npm install -g @guardian/cdk-cli
+$ cdk-cli COMMAND
 running command...
-$ cdk-migrator (-v|--version|version)
-@guardian/cdk-migrator/0.0.0 darwin-x64 node-v10.15.3
-$ cdk-migrator --help [COMMAND]
+$ cdk-cli (-v|--version|version)
+@guardian/cdk-cli/0.0.0 darwin-x64 node-v10.15.3
+$ cdk-cli --help [COMMAND]
 USAGE
-  $ cdk-migrator COMMAND
+  $ cdk-cli COMMAND
 ...
 ```
+
 <!-- usagestop -->
+
 # Commands
+
 <!-- commands -->
-* [`cdk-migrator help [COMMAND]`](#cdk-migrator-help-command)
-* [`cdk-migrator migrate TEMPLATE OUTPUT STACK`](#cdk-migrator-migrate-template-output-stack)
 
-## `cdk-migrator help [COMMAND]`
+- [`cdk-cli help [COMMAND]`](#cdk-cli-help-command)
+- [`cdk-cli migrate TEMPLATE OUTPUT STACK`](#cdk-cli-migrate-template-output-stack)
 
-display help for cdk-migrator
+## `cdk-cli help [COMMAND]`
+
+display help for cdk-cli
 
 ```
 USAGE
-  $ cdk-migrator help [COMMAND]
+  $ cdk-cli help [COMMAND]
 
 ARGUMENTS
   COMMAND  command to show help for
@@ -48,13 +55,13 @@ OPTIONS
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.0/src/commands/help.ts)_
 
-## `cdk-migrator migrate TEMPLATE OUTPUT STACK`
+## `cdk-cli migrate TEMPLATE OUTPUT STACK`
 
 Migrates from a cloudformation template to Guardian flavoured CDK
 
 ```
 USAGE
-  $ cdk-migrator migrate TEMPLATE OUTPUT STACK
+  $ cdk-cli migrate TEMPLATE OUTPUT STACK
 
 ARGUMENTS
   TEMPLATE  The template file to migrate
@@ -66,5 +73,6 @@ OPTIONS
   -v, --version  show CLI version
 ```
 
-_See code: [src/commands/migrate.ts](https://github.com/guardian/cdk-migrator/blob/v0.0.0/src/commands/migrate.ts)_
+_See code: [src/commands/migrate.ts](https://github.com/guardian/cdk-cli/blob/v0.0.0/src/commands/migrate.ts)_
+
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@guardian/cdk-migrator",
+  "name": "@guardian/cdk-cli",
   "description": "A CLI tool to migrate from cloudformation to Guardian flavoured CDK",
   "version": "0.0.0",
   "author": "The Guardian",
   "bin": {
-    "cdk-migrator": "./bin/run"
+    "cdk-cli": "./bin/run"
   },
-  "bugs": "https://github.com/guardian/cdk-migrator/issues",
+  "bugs": "https://github.com/guardian/cdk-cli/issues",
   "dependencies": {
     "@aws-cdk/core": "^1.73.0",
     "@oclif/command": "^1",
@@ -42,7 +42,7 @@
     "/bin",
     "/lib"
   ],
-  "homepage": "https://github.com/guardian/cdk-migrator",
+  "homepage": "https://github.com/guardian/cdk-cli",
   "keywords": [
     "oclif"
   ],
@@ -50,12 +50,12 @@
   "main": "lib/index.js",
   "oclif": {
     "commands": "./lib/commands",
-    "bin": "cdk-migrator",
+    "bin": "cdk-cli",
     "plugins": [
       "@oclif/plugin-help"
     ]
   },
-  "repository": "guardian/cdk-migrator",
+  "repository": "guardian/cdk-cli",
   "scripts": {
     "prepack": "rm -rf lib && tsc -b && oclif-dev readme",
     "build": "yarn prepack",


### PR DESCRIPTION
## What does this change?

This PR changes all the references to CDK migrator as part of the work to rename this repository. The rename is occurring in anticipation of further work to add functionality not solely related to migration.

## What to do when merging

- [ ] update the repository name
- [ ] update any references to this repository

## Have we considered potential risks

If, once the repository is renamed, another repository is created with the `guardian/cdk-migrator` name, any references will point to that repository rather than being redirected. To mitigate this, ensure we update any references when we make the change. As this is both new and has yet to be published, the impact on projects will it installed or scripts that reference it should be minimal.